### PR TITLE
Parametrize podman socket name

### DIFF
--- a/cmd/yggd/main.go
+++ b/cmd/yggd/main.go
@@ -127,6 +127,12 @@ func main() {
 			Value:  "cert-cn",
 			Hidden: true,
 		},
+		&cli.StringFlag{
+			Name:   "podman-socket-name",
+			Usage:  "Podman `SOCKET` to connect to",
+			Value:  "podman.sock",
+			Hidden: true,
+		},
 	}
 
 	// This BeforeFunc will load flag values from a config file only if the
@@ -296,6 +302,7 @@ func main() {
 			"PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
 			"BASE_CONFIG_DIR=" + configDir,
 			"LOG_LEVEL=" + level.String(),
+			"PODMAND_SOCKET_NAME=" + c.String("podman-socket-name"),
 		}
 		for _, info := range fileInfos {
 			if strings.HasSuffix(info.Name(), "worker") {


### PR DESCRIPTION
I wanted to run the agent on rhel8.2 and noticed that `podman.socket` is not there. I found it under different name:

```bash
ss -l -p | grep podman
u_str  LISTEN  0  128  /run/podman/io.podman 13964167  * 0  users:(("systemd",pid=1,fd=87))
```

This PR provides a way to customize it.

Signed-off-by: Piotr Kliczewski <piotr.kliczewski@gmail.com>