### PR TITLE
Allow for building binaries for other architectures

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,6 +66,11 @@ ifeq ($(shell find . -name vendor), ./vendor)
 BUILDFLAGS += -mod=vendor
 endif
 
+ARCH ?=
+ifneq ($ARCH,)
+	export GOARCH=$(ARCH)
+endif
+
 BINS = yggd ygg
 DATA = ygg.bash \
 	   ygg.1.gz \


### PR DESCRIPTION
This change adds possibility to build binaries for other platform. For example:
```shell
ARCH=arm64 make
```
Signed-off-by: Jakub Dzon <jdzon@redhat.com>